### PR TITLE
minimal setup for Unix script installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,28 @@
-from distutils.core import setup
-import py2exe
+#!/usr/bin/env python
 
-setup(options = {'py2exe': {'bundle_files': 1, 'compressed': True}},
-      console = ['LaTeXpkges.py'])
+"""latexpkges: LaTeX package cleanup utility
+
+Find packages included in your LaTeX document but not actually used.
+"""
+
+__version__ = "0.1.0a1"
+
+from distutils.core import setup
+try:
+    import py2exe
+except ImportError:
+    pass
+
+doclines = __doc__.splitlines()
+name, short_description = doclines[0].split(": ")
+long_description = "\n".join(doclines[2:])
+
+if __name__ == "__main__":
+    setup(name=name,
+          version=__version__,
+          description=short_description,
+          long_description=long_description,
+          python_requires='>=2, <3',
+          options={'py2exe': {'bundle_files': 1, 'compressed': True}},
+          console=['LaTeXpkges.py'],
+          scripts=['LaTeXpkges.py'])


### PR DESCRIPTION
Add to `setup.py` so that `python2 -m pip install .` will work.

Addresses #14 by removing a requirement for `py2exe`.

I would also suggest changing from `LaTeXpkges.py` to something that would be less awkward at the command-line. For example, `latexpkges`. This is really a separate matter but if this is to be disseminated further, fixing this now will be easier than later.